### PR TITLE
use custom casing instead of humps

### DIFF
--- a/lib/casing.js
+++ b/lib/casing.js
@@ -1,0 +1,55 @@
+const camelCaseRegex = /^[a-z][A-Za-z0-9]*$/;
+const camelSplitRegex = /(?=[A-Z])/;
+const snakeCaseRegex = /^[a-z]+(?:_[a-z0-9]+)*$/;
+const snakeCaptureRegex = /_(.)/g;
+
+exports.snek = snek;
+exports.desnek = desnek;
+
+// in the grass
+function snek(object) {
+	return processKeys(s => {
+		if (!camelCaseRegex.test(s))
+			return s;
+
+		return s
+			.split(camelSplitRegex)
+			.join('_')
+			.toLowerCase();
+	}, object);
+}
+
+function desnek(object) {
+	return processKeys(s => {
+		if (!snakeCaseRegex.test(s))
+			return s;
+
+		return s.replace(snakeCaptureRegex, (match, chr) => {
+			return chr ? chr.toUpperCase() : '';
+		});
+	}, object);
+}
+
+function processKeys(convert, obj) {
+	if (obj !== Object(obj) || typeof obj === 'function')
+		return obj;
+
+	if (['[object Date]', '[object RegExp]', '[object Boolean]'].includes(Object.prototype.toString.call(obj)))
+		return obj;
+
+	if (Array.isArray(obj)) {
+		const output = [];
+
+		for (const item of obj)
+			output.push(processKeys(convert, item));
+
+		return output;
+	}
+
+	const output = {};
+
+	for (const key of Object.keys(obj))
+		output[convert(key)] = processKeys(convert, obj[key]);
+
+	return output;
+}

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,5 @@
-const humps = require('humps');
 const jsonClient = require('json-client');
+const { snek, desnek } = require('./casing');
 
 module.exports = crpc;
 
@@ -7,9 +7,9 @@ function crpc(baseUrl, options) {
 	const client = jsonClient(baseUrl, options);
 
 	return function crpcRequest(path, body, options) {
-		const transformedBody = humps.decamelizeKeys(body);
+		const transformedBody = snek(body);
 
 		return client('post', path, null, transformedBody, options)
-			.then(humps.camelizeKeys);
+			.then(desnek);
 	};
 }

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
     "url": "https://github.com/billinghamj/crpc.git"
   },
   "dependencies": {
-    "humps": "^2.0.1",
     "json-client": "^0.9.2"
   },
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "crpc",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "Simple library for making requests to Cuvva-style RPC APIs",
   "homepage": "https://github.com/billinghamj/crpc",
   "bugs": "https://github.com/billinghamj/crpc/issues",


### PR DESCRIPTION
humps is changing the case of keys which shouldn't be changed such as kebab-case and others; this will instead only change snake case to camel case inbound, and camel case to snake case outbound